### PR TITLE
Adjust checkin screen to look complete on PTR

### DIFF
--- a/appinfo.json
+++ b/appinfo.json
@@ -23,7 +23,8 @@
         "configurable"
     ],
     "companyName": "Thomas Hunsaker",
-    "longName": "Spoon 2.1",
+    "enableMultiJS": false,
+    "longName": "Spoon",
     "projectType": "native",
     "resources": {
         "media": [
@@ -83,7 +84,7 @@
         "chalk"
     ],
     "uuid": "1cceab0a-8dc1-4641-b7b6-5ea9c827dd66",
-    "versionLabel": "2.1",
+    "versionLabel": "2.110",
     "watchapp": {
         "watchface": false
     }


### PR DESCRIPTION
Before:
![spoon-chalk-checkin-screen-busted](https://cloud.githubusercontent.com/assets/137686/12940298/e6546b50-cf84-11e5-8906-2eb484e13c86.png)

After:
![spoon-chalk-checked-screen](https://cloud.githubusercontent.com/assets/137686/12940309/ef64011a-cf84-11e5-852e-2e0939b64051.png)

Instead of pulsing the check mark (which I didn't really like) I'm showing a spinning indicator on PTR. I may add something similar to the other watches later. 
Example (not spinning):
![spoon-chalk-checkin-screen](https://cloud.githubusercontent.com/assets/137686/12940327/1304cc94-cf85-11e5-96d8-9a2a3119db62.png)
